### PR TITLE
fix(main): resolve package.json via __dirname instead of cwd

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -32,7 +32,10 @@ async function bootstrap() {
     next();
   });
 
-  const { version } = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8'));
+  // Resolve relative to this file, not cwd: entrypoint.sh `cd`s into
+  // backend/src before starting node, but package.json only ever lives at
+  // the backend root (one level up from src/ in both dev and prod).
+  const { version } = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
 
   const swaggerConfig = new DocumentBuilder()
     .setTitle('Invoicerr API')


### PR DESCRIPTION
entrypoint.sh cd's into backend/src before starting node, so process.cwd() never has a package.json (the Dockerfile only copies it to the backend root). This crashed every production boot reading the version for the Swagger config, right after the migration baseline/deploy step succeeds. Confirmed fixed against a deployment-accurate simulation of the Docker layout.