### PR TITLE
fix: only run the v1.4.4a leveling push on legacy db-push instances

### DIFF
--- a/backend/src/prisma/sync-schema.ts
+++ b/backend/src/prisma/sync-schema.ts
@@ -52,6 +52,11 @@ const V1_4_4A_BASELINE_MIGRATIONS = [
 // (entrypoint.sh `cd`s into backend/src before starting node).
 const BACKEND_ROOT = join(__dirname, '..', '..');
 const SCHEMA_PATH = join(BACKEND_ROOT, 'prisma', 'schema.prisma');
+// Frozen full schema as it shipped in v1.4.4a. Only used to level a legacy
+// `db push`-era instance (which may be *below* v1.4.4a) up to the exact
+// v1.4.4a state before we baseline the v1.4.4a migrations as applied — see
+// baselineIfNeeded(). Never pushed against an already-migrated DB.
+const V1_4_4A_SCHEMA_PATH = join(BACKEND_ROOT, 'prisma', 'schema-v1.4.4a.prisma');
 
 function runPrisma(args: string[]): void {
   // `prisma.config.ts`'s `migrations.path` is resolved relative to the
@@ -90,6 +95,19 @@ async function databaseHasExistingData(): Promise<boolean> {
  * live (V1_4_4A_BASELINE_MIGRATIONS) as already applied, then let
  * `migrate deploy` actually run everything newer — for real, backfills
  * included.
+ *
+ * Before baselining, we level the schema up to v1.4.4a with a one-off
+ * `db push` against the frozen v1.4.4a schema. A legacy instance may be
+ * running a version *below* v1.4.4a, so its DB can be a subset of v1.4.4a;
+ * marking the 23 v1.4.4a migrations "applied" on such a DB would otherwise
+ * be a lie (their changes aren't all there) and cause drift. The push only
+ * adds what's missing (their descriptions are still non-NULL — the
+ * NULL-clearing migration is post-v1.4.4a), and this whole branch is gated
+ * on `!migrationsTableExists()`, so it never runs against a DB already on
+ * the migrate-deploy system (where pushing back to v1.4.4a would drop every
+ * newer table/column). This used to live in entrypoint.sh but ran
+ * unconditionally there, wrongly converging already-migrated instances back
+ * down to v1.4.4a on every boot.
  */
 async function baselineIfNeeded(): Promise<void> {
   if (await migrationsTableExists()) {
@@ -102,7 +120,16 @@ async function baselineIfNeeded(): Promise<void> {
   }
 
   console.log(
-    '[sync-schema] Existing database with no migration history detected — baselining migrations confirmed already live as applied.',
+    '[sync-schema] Legacy db-push instance detected — leveling schema up to v1.4.4a before baselining.',
+  );
+  execFileSync(
+    'npx',
+    ['prisma', 'db', 'push', '--accept-data-loss', '--schema', V1_4_4A_SCHEMA_PATH],
+    { stdio: 'inherit', cwd: BACKEND_ROOT },
+  );
+
+  console.log(
+    '[sync-schema] Baselining migrations confirmed already live as applied.',
   );
 
   for (const migration of V1_4_4A_BASELINE_MIGRATIONS) {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,9 +30,11 @@ cat > /usr/share/nginx/html/config.json <<EOF
 }
 EOF
 
-# Push database schema using the standard Prisma command
-echo "Pushing database schema..."
-npx prisma db push --accept-data-loss --schema=/usr/share/nginx/backend/prisma/schema-v1.4.4a.prisma
+# Schema convergence (baseline + migrate deploy, and the one-off v1.4.4a
+# leveling push for legacy db-push instances) is handled inside the backend
+# at startup — see backend/src/prisma/sync-schema.ts. Doing it here
+# unconditionally wrongly converged already-migrated instances back to
+# v1.4.4a on every boot.
 
 # Start the backend service
 echo "Starting backend service..."


### PR DESCRIPTION
entrypoint.sh ran `prisma db push --schema schema-v1.4.4a.prisma` unconditionally on every boot. On an instance already migrated past v1.4.4a this fails ("description NOT NULL but NULL values exist", from the post-v1.4.4a NULL-clearing migration) and — more dangerously — would converge the DB back down to v1.4.4a, dropping every newer table/column (api_key, PdfDownloadToken, UserCompany, scopes, item name). Today only an accidental NOT-NULL abort prevents that data loss.

Move the leveling push into sync-schema.ts's baselineIfNeeded(), inside the legacy branch already gated on !migrationsTableExists() && hasExistingData(). It now runs only for legacy db-push-era instances (where it safely levels a sub-v1.4.4a schema up before baselining the 23 v1.4.4a migrations) and never for already-migrated instances (which take the early return). The baseline itself is unchanged.

Verified against a scratch Postgres for all three cases: already-migrated (no push, migrate deploy no-op), legacy (push -> baseline -> migrate deploy reaches the current schema with no drift), and fresh (pure migrate deploy).