### PR TITLE
fix: persist signedAt on quote when signature is completed

### DIFF
--- a/backend/src/modules/signatures/signatures.service.ts
+++ b/backend/src/modules/signatures/signatures.service.ts
@@ -298,11 +298,13 @@ export class SignaturesService {
             throw new BadRequestException('Invalid or expired OTP code.');
         }
 
+        const signedAt = new Date();
+
         await prisma.signature.update({
             where: { id: signature.id },
             data: {
                 otpUsed: true,
-                signedAt: new Date(),
+                signedAt,
             },
         });
 
@@ -310,6 +312,7 @@ export class SignaturesService {
             where: { id: signature.quoteId },
             data: {
                 status: 'SIGNED',
+                signedAt,
             },
         });
 
@@ -317,7 +320,7 @@ export class SignaturesService {
             await this.webhookDispatcher.dispatch(WebhookEvent.SIGNATURE_COMPLETED, {
                 signatureId,
                 quoteId: signature.quoteId,
-                signedAt: new Date(),
+                signedAt,
             });
         } catch (error) {
             logger.error('Failed to dispatch SIGNATURE_COMPLETED webhook', error);


### PR DESCRIPTION
Quote.signedAt was never written when a client signed a quote, so the "Signed at" field in the quote details panel stayed empty even for signed quotes. signQuote now writes the same timestamp to both the Signature and the Quote.

Fixes #381