### PR TITLE
fix: correct baseURL typo in better-auth config

### DIFF
--- a/backend/src/lib/auth.ts
+++ b/backend/src/lib/auth.ts
@@ -123,7 +123,7 @@ const userAfterCreateHook = async (user) => {
 };
 
 export const auth = betterAuth({    
-    baseUrl: process.env.APP_URL || 'http://localhost:3000',
+    baseURL: process.env.APP_URL || 'http://localhost:3000',
     trustedOrigins: ['http://localhost:5173', process.env.APP_URL, ...(process.env.CORS_ORIGINS?.split(',').map(o => o.trim()) || [])].filter((origin): origin is string => typeof origin === 'string'),
     database: prismaAdapter(prisma, {
         provider: "postgresql",


### PR DESCRIPTION
APP_URL was silently ignored because betterAuth() was called with baseUrl instead of the expected baseURL option, causing OIDC redirect URIs to fall back to http://localhost:3000 behind a reverse proxy.

Fixes #383