### PR TITLE
fix: show all webhook events as a list instead of truncated text

### DIFF
--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -1533,7 +1533,7 @@
                 "button": "Erstelle Webhook"
             },
             "card": {
-                "events": "Warte auf Ereignisse: {{events}}",
+                "events": "Warte auf Ereignisse:",
                 "edit": "Bearbeiten",
                 "delete": "Löschen",
                 "editPrompt": "Geben Sie eine neue webhook URL ein"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1860,7 +1860,7 @@
                 "button": "Create Webhook"
             },
             "card": {
-                "events": "Listening to events: {{events}}",
+                "events": "Listening to events:",
                 "edit": "Edit",
                 "delete": "Delete",
                 "editPrompt": "Enter new webhook URL"

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1533,7 +1533,7 @@
                 "button": "Create Webhook"
             },
             "card": {
-                "events": "Escuchando eventos: {{events}}",
+                "events": "Escuchando eventos:",
                 "edit": "Editar",
                 "delete": "Eliminar",
                 "editPrompt": "Introduce la nueva URL del webhook"

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1839,7 +1839,7 @@
                 "button": "Créer le webhook"
             },
             "card": {
-                "events": "Écoute les événements : {{events}}"
+                "events": "Écoute les événements :"
             }
         }
     },

--- a/frontend/src/pages/(app)/settings/_components/webhooks.settings.tsx
+++ b/frontend/src/pages/(app)/settings/_components/webhooks.settings.tsx
@@ -117,9 +117,14 @@ export default function WebhooksSettings() {
                                     <span className="font-medium">{wh.type}</span>
                                     <span className={`inline-block w-1/2 max-w-full text-xs text-muted-foreground truncate overflow-hidden`}>{wh.url}</span>
                                 </CardTitle>
-                                <CardDescription
-                                    className="w-4/5 overflow-hidden text-ellipsis text-nowrap"
-                                >{t('settings.webhooks.card.events', { events: wh.events.join(', ') })}</CardDescription>
+                                <CardDescription className="w-full">
+                                    <span>{t('settings.webhooks.card.events')}</span>
+                                    <ul className="mt-1 list-disc list-inside space-y-0.5">
+                                        {wh.events.map((event) => (
+                                            <li key={event} className="break-all">{event}</li>
+                                        ))}
+                                    </ul>
+                                </CardDescription>
                             </CardHeader>
                             <CardContent>
                                 <div className="w-full flex items-center gap-2">


### PR DESCRIPTION
## Summary
- The webhook settings card truncated the comma-separated events string with `text-ellipsis`, hiding events beyond what fit on one line.
- Events are now rendered as a bulleted list so all listened events are fully visible.
- Updated the `settings.webhooks.card.events` translation string in en/de/es/fr to drop the inline `{{events}}` interpolation, since events are now rendered as separate list items.

Fixes #394

🤖 Generated with [Claude Code](https://claude.ai/code)