### PR TITLE
fix: hide including/excluding VAT when rate is 0 or not applicable

### DIFF
--- a/backend/src/modules/invoices/invoices.service.ts
+++ b/backend/src/modules/invoices/invoices.service.ts
@@ -17,7 +17,7 @@ import { formatNotes, formatRichText } from '@/utils/format-text';
 import { logger } from '@/logger/logger.service';
 import { parseAddress } from '@/utils/adress';
 import prisma from '@/prisma/prisma.service';
-import { calculateDiscountedTotals, clampDiscountRate } from '@/utils/financial';
+import { calculateDiscountedTotals, clampDiscountRate, getVatDisplayContext } from '@/utils/financial';
 import { getDraftWatermarkLabel } from '@/utils/watermark';
 
 @Injectable()
@@ -432,6 +432,7 @@ export class InvoicesService {
         const normalizedDiscountRate = clampDiscountRate(invoice.discountRate);
         const discountAmountValue = Math.max(0, subtotalBeforeDiscount - invoice.totalHT);
         const hasDiscount = normalizedDiscountRate > 0 && discountAmountValue > 0;
+        const { showVat, totalsColspan } = getVatDisplayContext(invoice.totalVAT, invoice.items);
 
         const html = template({
             isDraft: invoice.status === 'DRAFT',
@@ -458,6 +459,8 @@ export class InvoicesService {
             discountAmount: formatAmount(discountAmountValue, invoice.company.country),
             discountRate: Number(normalizedDiscountRate.toFixed(2)),
             hasDiscount,
+            showVat,
+            totalsColspan,
             vatExemptText: invoice.company.exemptVat && (invoice.company.country || '').toUpperCase() === 'FRANCE' ? 'TVA non applicable, art. 293 B du CGI' : null,
 
             paymentMethod: paymentMethodName,

--- a/backend/src/modules/invoices/templates/base.template.ts
+++ b/backend/src/modules/invoices/templates/base.template.ts
@@ -103,7 +103,9 @@ export const baseTemplate = `
                 <th>{{labels.type}}</th>
                 <th>{{labels.quantity}}</th>
                 <th>{{labels.unitPrice}}</th>
+                {{#if showVat}}
                 <th>{{labels.vatRate}}</th>
+                {{/if}}
                 <th>{{labels.total}}</th>
             </tr>
         </thead>
@@ -114,34 +116,38 @@ export const baseTemplate = `
                 <td>{{type}}</td>
                 <td>{{quantity}}</td>
                 <td>{{../currency}} {{unitPrice}}</td>
+                {{#if ../showVat}}
                 <td>{{vatRate}}%</td>
+                {{/if}}
                 <td>{{../currency}} {{totalPrice}}</td>
             </tr>
             {{/each}}
         </tbody>
         <tfoot>
             <tr>
-                <td colspan="5"><strong>{{labels.subtotal}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.subtotal}}</strong></td>
                 <td><strong>{{currency}} {{subtotalBeforeDiscount}}</strong></td>
             </tr>
             {{#if hasDiscount}}
             <tr>
-                <td colspan="5"><strong>{{labels.discount}} ({{discountRate}}%)</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.discount}} ({{discountRate}}%)</strong></td>
                 <td><strong>-{{currency}} {{discountAmount}}</strong></td>
             </tr>
             {{/if}}
+            {{#if showVat}}
             <tr>
-                <td colspan="5"><strong>{{labels.vat}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.vat}}</strong></td>
                 <td><strong>{{currency}} {{totalVAT}}</strong></td>
             </tr>
+            {{/if}}
             {{#if vatExemptText}}
             <tr>
                 <td></td>
-                <td colspan="5" style="font-size:12px; color:#666; text-align:right;"><em>{{vatExemptText}}</em></td>
+                <td colspan="{{totalsColspan}}" style="font-size:12px; color:#666; text-align:right;"><em>{{vatExemptText}}</em></td>
             </tr>
             {{/if}}
             <tr class="total-row">
-                <td colspan="5"><strong>{{labels.grandTotal}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{#if showVat}}{{labels.grandTotal}}{{else}}{{labels.total}}{{/if}}</strong></td>
                 <td><strong>{{currency}} {{totalTTC}}</strong></td>
             </tr>
         </tfoot>

--- a/backend/src/modules/quotes/quotes.service.ts
+++ b/backend/src/modules/quotes/quotes.service.ts
@@ -14,7 +14,7 @@ import { formatAmount } from '@/utils/format-amount';
 import { formatDate } from '@/utils/date';
 import { logger } from '@/logger/logger.service';
 import prisma from '@/prisma/prisma.service';
-import { calculateDiscountedTotals, clampDiscountRate } from '@/utils/financial';
+import { calculateDiscountedTotals, clampDiscountRate, getVatDisplayContext } from '@/utils/financial';
 import { formatNotes, formatRichText } from '@/utils/format-text';
 import { getDraftWatermarkLabel } from '@/utils/watermark';
 
@@ -442,6 +442,7 @@ export class QuotesService {
         const normalizedDiscountRate = clampDiscountRate(quote.discountRate);
         const discountAmountValue = Math.max(0, subtotalBeforeDiscount - quote.totalHT);
         const hasDiscount = normalizedDiscountRate > 0 && discountAmountValue > 0;
+        const { showVat, totalsColspan } = getVatDisplayContext(quote.totalVAT, quote.items);
 
         const html = template({
             number: quote.rawNumber || quote.number.toString(),
@@ -466,6 +467,8 @@ export class QuotesService {
             discountAmount: formatAmount(discountAmountValue, quote.company.country),
             discountRate: Number(normalizedDiscountRate.toFixed(2)),
             hasDiscount,
+            showVat,
+            totalsColspan,
             vatExemptText: quote.company.exemptVat && (quote.company.country || '').toUpperCase() === 'FRANCE' ? 'TVA non applicable, art. 293 B du CGI' : null,
 
             paymentMethod: paymentMethodType,

--- a/backend/src/modules/quotes/templates/base.template.ts
+++ b/backend/src/modules/quotes/templates/base.template.ts
@@ -24,6 +24,8 @@ export const baseTemplate = `
         .items-table th:nth-child(4), .items-table td:nth-child(4) { width: 16%; }
         .items-table th:nth-child(5), .items-table td:nth-child(5) { width: 9%; }
         .items-table th:nth-child(6), .items-table td:nth-child(6) { width: 18%; }
+        .items-table.no-vat th:nth-child(1), .items-table.no-vat td:nth-child(1) { width: 47%; }
+        .items-table.no-vat th:nth-child(5), .items-table.no-vat td:nth-child(5) { width: 18%; }
         .total-row { font-weight: bold; background-color: {{secondaryColor}}; color: {{tableTextColor}}; }
         .totals-table { width: 100%; border-collapse: collapse; margin: 0 0 20px; page-break-inside: avoid; break-inside: avoid; }
         .totals-table td:last-child { text-align: right; }
@@ -106,14 +108,16 @@ export const baseTemplate = `
             {{#if client.VAT}}<br><strong>{{labels.VATId}}:</strong> {{client.VAT}}{{/if}}</p>
         </div>
     </div>
-    <table class="items-table">
+    <table class="items-table{{#unless showVat}} no-vat{{/unless}}">
         <thead>
             <tr>
                 <th>{{labels.description}}</th>
                 <th>{{labels.type}}</th>
                 <th>{{labels.quantity}}</th>
                 <th>{{labels.unitPrice}}</th>
+                {{#if showVat}}
                 <th>{{labels.vatRate}}</th>
+                {{/if}}
                 <th>{{labels.total}}</th>
             </tr>
         </thead>
@@ -124,7 +128,9 @@ export const baseTemplate = `
                 <td>{{type}}</td>
                 <td>{{quantity}}</td>
                 <td>{{../currency}} {{unitPrice}}</td>
+                {{#if ../showVat}}
                 <td>{{vatRate}}%</td>
+                {{/if}}
                 <td>{{../currency}} {{totalPrice}}</td>
             </tr>
             {{/each}}
@@ -133,27 +139,29 @@ export const baseTemplate = `
     <table class="totals-table">
         <tbody>
             <tr>
-                <td colspan="5"><strong>{{labels.subtotal}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.subtotal}}</strong></td>
                 <td><strong>{{currency}} {{subtotalBeforeDiscount}}</strong></td>
             </tr>
             {{#if hasDiscount}}
             <tr>
-                <td colspan="5"><strong>{{labels.discount}} ({{discountRate}}%)</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.discount}} ({{discountRate}}%)</strong></td>
                 <td><strong>-{{currency}} {{discountAmount}}</strong></td>
             </tr>
             {{/if}}
+            {{#if showVat}}
             <tr>
-                <td colspan="5"><strong>{{labels.vat}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.vat}}</strong></td>
                 <td><strong>{{currency}} {{totalVAT}}</strong></td>
             </tr>
+            {{/if}}
             {{#if vatExemptText}}
             <tr>
                 <td></td>
-                <td colspan="5" style="font-size:12px; color:#666; text-align:right;"><em>{{vatExemptText}}</em></td>
+                <td colspan="{{totalsColspan}}" style="font-size:12px; color:#666; text-align:right;"><em>{{vatExemptText}}</em></td>
             </tr>
             {{/if}}
             <tr class="total-row">
-                <td colspan="5"><strong>{{labels.grandTotal}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{#if showVat}}{{labels.grandTotal}}{{else}}{{labels.total}}{{/if}}</strong></td>
                 <td><strong>{{currency}} {{totalTTC}}</strong></td>
             </tr>
         </tbody>

--- a/backend/src/utils/financial.spec.ts
+++ b/backend/src/utils/financial.spec.ts
@@ -1,0 +1,104 @@
+import * as Handlebars from 'handlebars';
+
+import { getVatDisplayContext, isVatApplicable } from './financial';
+import { baseTemplate as invoiceTemplate } from '@/modules/invoices/templates/base.template';
+import { baseTemplate as quoteTemplate } from '@/modules/quotes/templates/base.template';
+
+describe('isVatApplicable', () => {
+    it('hides VAT when the rate is 0 / not applicable (USA)', () => {
+        expect(isVatApplicable(0, [{ vatRate: 0 }])).toBe(false);
+        expect(isVatApplicable(0, [{ vatRate: 0 }, { vatRate: null }])).toBe(false);
+        expect(isVatApplicable(0, [])).toBe(false);
+        expect(isVatApplicable(0)).toBe(false);
+        expect(isVatApplicable(null, undefined)).toBe(false);
+    });
+
+    it('keeps VAT when a real rate applies', () => {
+        expect(isVatApplicable(200, [{ vatRate: 20 }])).toBe(true);
+        expect(isVatApplicable(0, [{ vatRate: 5.5 }])).toBe(true);
+        expect(isVatApplicable(0, [{ vatRate: 0 }, { vatRate: 20 }])).toBe(true);
+        expect(isVatApplicable(12.5, [])).toBe(true);
+    });
+});
+
+describe('getVatDisplayContext', () => {
+    it('uses a 4-column totals colspan when VAT is hidden', () => {
+        expect(getVatDisplayContext(0, [{ vatRate: 0 }])).toEqual({
+            showVat: false,
+            totalsColspan: 4,
+        });
+    });
+
+    it('uses a 5-column totals colspan when VAT is shown', () => {
+        expect(getVatDisplayContext(20, [{ vatRate: 20 }])).toEqual({
+            showVat: true,
+            totalsColspan: 5,
+        });
+    });
+});
+
+const pdfLabels = {
+    invoice: 'Invoice',
+    quote: 'Quote',
+    date: 'Date',
+    dueDate: 'Due date',
+    validUntil: 'Valid until',
+    billTo: 'Bill to',
+    quoteFor: 'Quote for',
+    description: 'Description',
+    type: 'Type',
+    quantity: 'Quantity',
+    unitPrice: 'Unit price',
+    vatRate: 'VAT Rate',
+    total: 'Total',
+    subtotal: 'Subtotal',
+    vat: 'VAT',
+    grandTotal: 'Grand Total',
+};
+
+function renderTemplate(source: string, showVat: boolean) {
+    const { totalsColspan } = getVatDisplayContext(showVat ? 20 : 0, [{ vatRate: showVat ? 20 : 0 }]);
+    return Handlebars.compile(source)({
+        number: '1',
+        date: '01/01/2026',
+        dueDate: '31/01/2026',
+        validUntil: '31/01/2026',
+        company: { name: 'Acme', address: '1 Main', city: 'NY', postalCode: '10001', country: 'USA', email: 'a@a.com', phone: '1' },
+        client: { name: 'Jane', address: '2 Main', city: 'LA', postalCode: '90001', country: 'USA' },
+        currency: 'USD',
+        items: [{ name: 'Work', type: 'Service', quantity: '1', unitPrice: '100.00', vatRate: showVat ? '20.00' : '0.00', totalPrice: showVat ? '120.00' : '100.00' }],
+        totalHT: '100.00',
+        totalVAT: showVat ? '20.00' : '0.00',
+        totalTTC: showVat ? '120.00' : '100.00',
+        subtotalBeforeDiscount: '100.00',
+        showVat,
+        totalsColspan,
+        labels: pdfLabels,
+    });
+}
+
+describe('PDF VAT columns', () => {
+    it.each([
+        ['invoice', invoiceTemplate],
+        ['quote', quoteTemplate],
+    ])('omits VAT rate and VAT total on %s PDFs when VAT is 0', (_kind, template) => {
+        const html = renderTemplate(template, false);
+        expect(html).not.toContain('VAT Rate');
+        expect(html).not.toMatch(/>\s*VAT\s*</);
+        expect(html).not.toContain('Grand Total');
+        expect(html).toContain('Total');
+        expect(html).toContain('100.00');
+    });
+
+    it.each([
+        ['invoice', invoiceTemplate],
+        ['quote', quoteTemplate],
+    ])('keeps VAT rate and VAT total on %s PDFs when a real rate applies', (_kind, template) => {
+        const html = renderTemplate(template, true);
+        expect(html).toContain('VAT Rate');
+        expect(html).toContain('20.00');
+        expect(html).toMatch(/>\s*VAT\s*</);
+        expect(html).toContain('Grand Total');
+        expect(html).toContain('120.00');
+    });
+});

--- a/backend/src/utils/financial.ts
+++ b/backend/src/utils/financial.ts
@@ -25,6 +25,29 @@ export function clampDiscountRate(rate?: number | null): number {
     return Math.min(Math.max(rate, 0), 100);
 }
 
+/**
+ * VAT including/excluding UI and PDF columns are shown only when a real rate
+ * applies (any line vatRate > 0 or a non-zero VAT total). 0% and VAT-exempt
+ * documents (e.g. USA, FR 293 B CGI) display a single Total instead.
+ */
+export function isVatApplicable(
+    totalVAT?: number | null,
+    items?: Array<{ vatRate?: number | null }> | null,
+): boolean {
+    if ((Number(totalVAT) || 0) > 0) {
+        return true;
+    }
+    return (items ?? []).some((item) => (Number(item.vatRate) || 0) > 0);
+}
+
+export function getVatDisplayContext(
+    totalVAT?: number | null,
+    items?: Array<{ vatRate?: number | null }> | null,
+): { showVat: boolean; totalsColspan: number } {
+    const showVat = isVatApplicable(totalVAT, items);
+    return { showVat, totalsColspan: showVat ? 5 : 4 };
+}
+
 export function calculateDiscountedTotals(
     items: FinancialLineItem[],
     discountRate: number,

--- a/backend/src/utils/generate-quote-pdf.ts
+++ b/backend/src/utils/generate-quote-pdf.ts
@@ -6,7 +6,7 @@ import { BadRequestException } from '@nestjs/common';
 import { baseTemplate } from '@/modules/quotes/templates/base.template';
 import { formatDate } from '@/utils/date';
 import prisma from '@/prisma/prisma.service';
-import { clampDiscountRate } from '@/utils/financial';
+import { clampDiscountRate, getVatDisplayContext } from '@/utils/financial';
 import { formatNotes, formatRichText } from '@/utils/format-text';
 import { formatAmount } from '@/utils/format-amount';
 import { getDraftWatermarkLabel } from '@/utils/watermark';
@@ -72,6 +72,7 @@ export async function generateQuotePdf(quoteId: string): Promise<Uint8Array> {
     const normalizedDiscountRate = clampDiscountRate(quote.discountRate);
     const discountAmountValue = Math.max(0, subtotalBeforeDiscount - quote.totalHT);
     const hasDiscount = normalizedDiscountRate > 0 && discountAmountValue > 0;
+    const { showVat, totalsColspan } = getVatDisplayContext(quote.totalVAT, quote.items);
 
     const html = template({
         number: quote.rawNumber || quote.number.toString(),
@@ -96,6 +97,8 @@ export async function generateQuotePdf(quoteId: string): Promise<Uint8Array> {
         discountAmount: formatAmount(discountAmountValue, quote.company.country),
         discountRate: Number(normalizedDiscountRate.toFixed(2)),
         hasDiscount,
+        showVat,
+        totalsColspan,
         vatExemptText: quote.company.exemptVat && (quote.company.country || '').toUpperCase() === 'FRANCE' ? 'TVA non applicable, art. 293 B du CGI' : null,
 
         paymentMethod: paymentMethodType,

--- a/backend/src/utils/quote-pdf.ts
+++ b/backend/src/utils/quote-pdf.ts
@@ -6,7 +6,7 @@ import { BadRequestException } from '@nestjs/common';
 import { baseTemplate } from '@/modules/quotes/templates/base.template';
 import { formatDate } from '@/utils/date';
 import prisma from '@/prisma/prisma.service';
-import { clampDiscountRate } from '@/utils/financial';
+import { clampDiscountRate, getVatDisplayContext } from '@/utils/financial';
 import { formatAmount } from '@/utils/format-amount';
 import { formatNotes, formatRichText } from '@/utils/format-text';
 import { getDraftWatermarkLabel } from '@/utils/watermark';
@@ -68,6 +68,7 @@ export async function generateQuotePdf(id: string): Promise<Uint8Array> {
     const normalizedDiscountRate = clampDiscountRate(quote.discountRate);
     const discountAmountValue = Math.max(0, subtotalBeforeDiscount - quote.totalHT);
     const hasDiscount = normalizedDiscountRate > 0 && discountAmountValue > 0;
+    const { showVat, totalsColspan } = getVatDisplayContext(quote.totalVAT, quote.items);
 
     const html = template({
         number: quote.rawNumber || quote.number.toString(),
@@ -92,6 +93,8 @@ export async function generateQuotePdf(id: string): Promise<Uint8Array> {
         discountAmount: formatAmount(discountAmountValue, quote.company.country),
         discountRate: Number(normalizedDiscountRate.toFixed(2)),
         hasDiscount,
+        showVat,
+        totalsColspan,
         vatExemptText: quote.company.exemptVat && (quote.company.country || '').toUpperCase() === 'FRANCE' ? 'TVA non applicable, art. 293 B du CGI' : null,
 
         paymentMethod: paymentMethodType,

--- a/e2e/cypress/e2e/07-invoices.cy.ts
+++ b/e2e/cypress/e2e/07-invoices.cy.ts
@@ -38,6 +38,10 @@ describe('Invoices E2E', () => {
             cy.get('[data-cy="invoice-name"]').first().click();
             cy.get('[role="dialog"]').should('be.visible');
             cy.contains(/1[.,\s]?800/, { timeout: 10000 });
+            cy.get('[data-cy="invoice-total-ht"]').should('be.visible');
+            cy.get('[data-cy="invoice-total-vat"]').should('be.visible');
+            cy.get('[data-cy="invoice-total-ttc"]').should('be.visible');
+            cy.get('[data-cy="invoice-total"]').should('not.exist');
             cy.get('body').type('{esc}');
         });
 
@@ -166,6 +170,10 @@ describe('Invoices E2E', () => {
             cy.get('[data-cy="invoice-name"]').first().click();
             cy.get('[role="dialog"]').should('be.visible');
             cy.contains(/1[.,\s]?000/, { timeout: 10000 });
+            cy.get('[data-cy="invoice-total"]').should('be.visible');
+            cy.get('[data-cy="invoice-total-ht"]').should('not.exist');
+            cy.get('[data-cy="invoice-total-vat"]').should('not.exist');
+            cy.get('[data-cy="invoice-total-ttc"]').should('not.exist');
             cy.get('body').type('{esc}');
         });
 

--- a/frontend/src/lib/vat.ts
+++ b/frontend/src/lib/vat.ts
@@ -1,0 +1,13 @@
+/**
+ * Show including/excluding VAT only when a real rate applies.
+ * 0% and VAT-not-applicable documents (e.g. USA) use a single Total.
+ */
+export function isVatApplicable(
+    totalVAT?: number | null,
+    items?: Array<{ vatRate?: number | null }> | null,
+): boolean {
+    if ((Number(totalVAT) || 0) > 0) {
+        return true
+    }
+    return (items ?? []).some((item) => (Number(item.vatRate) || 0) > 0)
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -246,6 +246,7 @@
                 "client": "Client",
                 "issued": "Issued",
                 "validUntil": "Valid Until",
+                "total": "Total",
                 "totalHT": "Total (excl. VAT)",
                 "totalTTC": "Total (incl. VAT)"
             },
@@ -470,6 +471,7 @@
                 "signedBy": "Signed By",
                 "discountRate": "Discount Rate",
                 "discountAmount": "Discount Amount",
+                "total": "Total",
                 "totalHT": "Total (excl. VAT)",
                 "totalVAT": "VAT Amount",
                 "totalTTC": "Total (incl. VAT)",
@@ -623,6 +625,7 @@
                 "due": "Due",
                 "nextInvoiceDate": "Next invoice on",
                 "payment": "Payment",
+                "total": "Total",
                 "totalHT": "Total (excl. VAT)",
                 "totalTTC": "Total (incl. VAT)"
             },
@@ -789,6 +792,7 @@
                 "paymentMethod": "Payment Method",
                 "discountRate": "Discount Rate",
                 "discountAmount": "Discount Amount",
+                "total": "Total",
                 "totalHT": "Total (excl. VAT)",
                 "totalVAT": "VAT Amount",
                 "totalTTC": "Total (incl. VAT)",
@@ -853,6 +857,7 @@
             "item": {
                 "client": "Client",
                 "payment": "Payment Method",
+                "total": "Total",
                 "totalHT": "Total (excl. VAT)",
                 "totalTTC": "Total (incl. VAT)"
             },
@@ -984,6 +989,19 @@
                 "cancel": "Cancel",
                 "create": "Create Recurring Invoice",
                 "save": "Save Changes"
+            }
+        },
+        "view": {
+            "title": "Recurring Invoice",
+            "description": "View all details of this recurring invoice.",
+            "fields": {
+                "client": "Client",
+                "paymentMethod": "Payment Method",
+                "total": "Total",
+                "totalHT": "Total (excl. VAT)",
+                "totalVAT": "VAT Amount",
+                "totalTTC": "Total (incl. VAT)",
+                "notes": "Notes"
             }
         }
     },

--- a/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-list.tsx
@@ -13,6 +13,7 @@ import { InvoiceUpsert } from "./invoice-upsert"
 import { InvoiceViewDialog } from "./invoice-view"
 import { SendConfirmationDialog } from "@/components/send-confirmation-dialog"
 import { formatAmount } from "@/lib/utils"
+import { isVatApplicable } from "@/lib/vat"
 import type React from "react"
 import { toast } from "sonner"
 import { useNavigate } from "react-router"
@@ -275,6 +276,8 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                                                     {((invoice.paymentMethod as any)?.name ?? (invoice.paymentMethod as any)?.type) ?? "-"}
                                                                 </span>
                                                             )}
+                                                            {isVatApplicable(invoice.totalVAT, invoice.items) ? (
+                                                                <>
                                                             <span>
                                                                 <span className="font-medium text-foreground">{t("invoices.list.item.totalHT")}:</span>{" "}
                                                                 {t("common.valueWithCurrency", {
@@ -289,6 +292,16 @@ export const InvoiceList = forwardRef<InvoiceListHandle, InvoiceListProps>(
                                                                     amount: formatAmount(invoice.totalTTC, invoice.company?.country),
                                                                 })}
                                                             </span>
+                                                                </>
+                                                            ) : (
+                                                            <span>
+                                                                <span className="font-medium text-foreground">{t("invoices.list.item.total")}:</span>{" "}
+                                                                {t("common.valueWithCurrency", {
+                                                                    currency: invoice.currency,
+                                                                    amount: formatAmount(invoice.totalTTC, invoice.company?.country),
+                                                                })}
+                                                            </span>
+                                                            )}
                                                         </div>
                                                     </div>
                                                 </div>

--- a/frontend/src/pages/(app)/invoices/_components/invoice-view.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/invoice-view.tsx
@@ -6,6 +6,7 @@ import { format } from "date-fns"
 import { languageToLocale } from "@/lib/i18n"
 import { formatAmount } from "@/lib/utils"
 import { getDraftWatermarkLabel } from "@/lib/watermark"
+import { isVatApplicable } from "@/lib/vat"
 import { useTranslation } from "react-i18next"
 
 interface InvoiceViewDialogProps {
@@ -22,6 +23,7 @@ export function InvoiceViewDialog({ invoice, onOpenChange }: InvoiceViewDialogPr
     const discountRateValue = Number(invoice.discountRate ?? 0)
     const subtotalBeforeDiscount = invoice.items?.reduce((sum, item) => sum + (item.quantity * item.unitPrice), 0) ?? 0
     const discountAmount = Math.max(0, subtotalBeforeDiscount - invoice.totalHT)
+    const showVat = isVatApplicable(invoice.totalVAT, invoice.items)
 
     const getStatusLabel = (status: string) => {
         return t(`invoices.view.status.${getDisplayInvoiceStatus(status).toLowerCase()}`)
@@ -103,30 +105,42 @@ export function InvoiceViewDialog({ invoice, onOpenChange }: InvoiceViewDialogPr
                         </div>
                     </div>
 
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 bg-muted/50 p-4 rounded-lg">
-                        <div>
-                            <p className="text-sm text-muted-foreground">{t("invoices.view.fields.totalHT")}</p>
-                            <p className="font-medium">{t("common.valueWithCurrency", {
-                                currency: invoice.currency,
-                                amount: formatAmount(invoice.totalHT, invoice.company?.country)
-                            })}</p>
-                        </div>
+                    <div className={`grid grid-cols-1 ${showVat ? "sm:grid-cols-3" : ""} gap-6 bg-muted/50 p-4 rounded-lg`}>
+                        {showVat ? (
+                            <>
+                                <div data-cy="invoice-total-ht">
+                                    <p className="text-sm text-muted-foreground">{t("invoices.view.fields.totalHT")}</p>
+                                    <p className="font-medium">{t("common.valueWithCurrency", {
+                                        currency: invoice.currency,
+                                        amount: formatAmount(invoice.totalHT, invoice.company?.country)
+                                    })}</p>
+                                </div>
 
-                        <div>
-                            <p className="text-sm text-muted-foreground">{t("invoices.view.fields.totalVAT")}</p>
-                            <p className="font-medium">{t("common.valueWithCurrency", {
-                                currency: invoice.currency,
-                                amount: formatAmount(invoice.totalVAT, invoice.company?.country)
-                            })}</p>
-                        </div>
+                                <div data-cy="invoice-total-vat">
+                                    <p className="text-sm text-muted-foreground">{t("invoices.view.fields.totalVAT")}</p>
+                                    <p className="font-medium">{t("common.valueWithCurrency", {
+                                        currency: invoice.currency,
+                                        amount: formatAmount(invoice.totalVAT, invoice.company?.country)
+                                    })}</p>
+                                </div>
 
-                        <div>
-                            <p className="text-sm text-muted-foreground">{t("invoices.view.fields.totalTTC")}</p>
-                            <p className="font-medium">{t("common.valueWithCurrency", {
-                                currency: invoice.currency,
-                                amount: formatAmount(invoice.totalTTC, invoice.company?.country)
-                            })}</p>
-                        </div>
+                                <div data-cy="invoice-total-ttc">
+                                    <p className="text-sm text-muted-foreground">{t("invoices.view.fields.totalTTC")}</p>
+                                    <p className="font-medium">{t("common.valueWithCurrency", {
+                                        currency: invoice.currency,
+                                        amount: formatAmount(invoice.totalTTC, invoice.company?.country)
+                                    })}</p>
+                                </div>
+                            </>
+                        ) : (
+                            <div data-cy="invoice-total">
+                                <p className="text-sm text-muted-foreground">{t("invoices.view.fields.total")}</p>
+                                <p className="font-medium">{t("common.valueWithCurrency", {
+                                    currency: invoice.currency,
+                                    amount: formatAmount(invoice.totalTTC, invoice.company?.country)
+                                })}</p>
+                            </div>
+                        )}
                     </div>
 
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 bg-muted/50 p-4 rounded-lg">

--- a/frontend/src/pages/(app)/invoices/_components/recurring-invoices/recurring-invoices-list.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/recurring-invoices/recurring-invoices-list.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import type React from "react"
 import type { RecurringInvoice } from "@/types"
 import { formatAmount } from "@/lib/utils"
+import { isVatApplicable } from "@/lib/vat"
 import { RecurringInvoiceDeleteDialog } from "./recurring-invoices-delete"
 import { RecurringInvoiceUpsert } from "./recurring-invoices-upsert"
 import { RecurringInvoiceViewDialog } from "./recurring-invoices-view"
@@ -111,6 +112,8 @@ export const RecurringInvoiceList = forwardRef<RecurringInvoiceListHandle, Recur
                                                                     {((recurringInvoice.paymentMethod as any)?.name ?? (recurringInvoice.paymentMethod as any)?.type) ?? "-"}
                                                                 </span>
                                                             )}
+                                                            {isVatApplicable(recurringInvoice.totalVAT, recurringInvoice.items) ? (
+                                                                <>
                                                             <span>
                                                                 <span className="font-medium text-foreground">{t("recurringInvoices.list.item.totalHT")}:</span>{" "}
                                                                 {t("common.valueWithCurrency", {
@@ -125,6 +128,16 @@ export const RecurringInvoiceList = forwardRef<RecurringInvoiceListHandle, Recur
                                                                     amount: formatAmount(recurringInvoice.totalTTC, recurringInvoice.company?.country),
                                                                 })}
                                                             </span>
+                                                                </>
+                                                            ) : (
+                                                            <span>
+                                                                <span className="font-medium text-foreground">{t("recurringInvoices.list.item.total")}:</span>{" "}
+                                                                {t("common.valueWithCurrency", {
+                                                                    currency: recurringInvoice.currency,
+                                                                    amount: formatAmount(recurringInvoice.totalTTC, recurringInvoice.company?.country),
+                                                                })}
+                                                            </span>
+                                                            )}
                                                         </div>
                                                     </div>
                                                 </div>

--- a/frontend/src/pages/(app)/invoices/_components/recurring-invoices/recurring-invoices-view.tsx
+++ b/frontend/src/pages/(app)/invoices/_components/recurring-invoices/recurring-invoices-view.tsx
@@ -2,6 +2,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 
 import type { RecurringInvoice } from "@/types"
 import { formatAmount } from "@/lib/utils"
+import { isVatApplicable } from "@/lib/vat"
 import { useTranslation } from "react-i18next"
 
 interface RecurringInvoiceViewDialogProps {
@@ -13,6 +14,8 @@ export function RecurringInvoiceViewDialog({ recurringInvoice, onOpenChange }: R
     const { t } = useTranslation()
 
     if (!recurringInvoice) return null
+
+    const showVat = isVatApplicable(recurringInvoice.totalVAT, recurringInvoice.items)
 
     return (
         <Dialog open={!!recurringInvoice} onOpenChange={onOpenChange}>
@@ -41,21 +44,30 @@ export function RecurringInvoiceViewDialog({ recurringInvoice, onOpenChange }: R
                         </div>
                     </div>
 
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 bg-muted/50 p-4 rounded-lg">
-                        <div>
-                            <p className="text-sm text-muted-foreground">{t("recurringInvoices.view.fields.totalHT")}</p>
-                            <p className="font-medium">{t("common.valueWithCurrency", { amount: formatAmount(recurringInvoice.totalHT, recurringInvoice.company?.country), currency: recurringInvoice.currency })}</p>
-                        </div>
+                    <div className={`grid grid-cols-1 ${showVat ? "sm:grid-cols-3" : ""} gap-6 bg-muted/50 p-4 rounded-lg`}>
+                        {showVat ? (
+                            <>
+                                <div>
+                                    <p className="text-sm text-muted-foreground">{t("recurringInvoices.view.fields.totalHT")}</p>
+                                    <p className="font-medium">{t("common.valueWithCurrency", { amount: formatAmount(recurringInvoice.totalHT, recurringInvoice.company?.country), currency: recurringInvoice.currency })}</p>
+                                </div>
 
-                        <div>
-                            <p className="text-sm text-muted-foreground">{t("recurringInvoices.view.fields.totalVAT")}</p>
-                            <p className="font-medium">{t("common.valueWithCurrency", { amount: formatAmount(recurringInvoice.totalVAT, recurringInvoice.company?.country), currency: recurringInvoice.currency })}</p>
-                        </div>
+                                <div>
+                                    <p className="text-sm text-muted-foreground">{t("recurringInvoices.view.fields.totalVAT")}</p>
+                                    <p className="font-medium">{t("common.valueWithCurrency", { amount: formatAmount(recurringInvoice.totalVAT, recurringInvoice.company?.country), currency: recurringInvoice.currency })}</p>
+                                </div>
 
-                        <div>
-                            <p className="text-sm text-muted-foreground">{t("recurringInvoices.view.fields.totalTTC")}</p>
-                            <p className="font-medium">{t("common.valueWithCurrency", { amount: formatAmount(recurringInvoice.totalTTC, recurringInvoice.company?.country), currency: recurringInvoice.currency })}</p>
-                        </div>
+                                <div>
+                                    <p className="text-sm text-muted-foreground">{t("recurringInvoices.view.fields.totalTTC")}</p>
+                                    <p className="font-medium">{t("common.valueWithCurrency", { amount: formatAmount(recurringInvoice.totalTTC, recurringInvoice.company?.country), currency: recurringInvoice.currency })}</p>
+                                </div>
+                            </>
+                        ) : (
+                            <div>
+                                <p className="text-sm text-muted-foreground">{t("recurringInvoices.view.fields.total")}</p>
+                                <p className="font-medium">{t("common.valueWithCurrency", { amount: formatAmount(recurringInvoice.totalTTC, recurringInvoice.company?.country), currency: recurringInvoice.currency })}</p>
+                            </div>
+                        )}
                     </div>
 
                     {recurringInvoice.notes && (

--- a/frontend/src/pages/(app)/quotes/_components/quote-list.tsx
+++ b/frontend/src/pages/(app)/quotes/_components/quote-list.tsx
@@ -16,6 +16,7 @@ import { QuoteUpsert } from "@/pages/(app)/quotes/_components/quote-upsert"
 import { QuoteViewDialog } from "@/pages/(app)/quotes/_components/quote-view"
 import { SendConfirmationDialog } from "@/components/send-confirmation-dialog"
 import { formatAmount } from "@/lib/utils"
+import { isVatApplicable } from "@/lib/vat"
 import type React from "react"
 import { Spinner } from "@/components/ui/spinner"
 import { toast } from "sonner"
@@ -258,6 +259,8 @@ export const QuoteList = forwardRef<QuoteListHandle, QuoteListProps>(
                                                                     {new Date(quote.validUntil).toLocaleDateString()}
                                                                 </span>
                                                             )}
+                                                            {isVatApplicable(quote.totalVAT, quote.items) ? (
+                                                                <>
                                                             <span>
                                                                 <span className="font-medium text-foreground">{t("quotes.list.item.totalHT")}:</span>{" "}
                                                                 {t("common.valueWithCurrency", {
@@ -272,6 +275,16 @@ export const QuoteList = forwardRef<QuoteListHandle, QuoteListProps>(
                                                                     amount: formatAmount(quote.totalTTC, quote.company?.country),
                                                                 })}
                                                             </span>
+                                                                </>
+                                                            ) : (
+                                                            <span>
+                                                                <span className="font-medium text-foreground">{t("quotes.list.item.total")}:</span>{" "}
+                                                                {t("common.valueWithCurrency", {
+                                                                    currency: quote.currency,
+                                                                    amount: formatAmount(quote.totalTTC, quote.company?.country),
+                                                                })}
+                                                            </span>
+                                                            )}
                                                         </div>
                                                     </div>
                                                 </div>

--- a/frontend/src/pages/(app)/quotes/_components/quote-preview-template.ts
+++ b/frontend/src/pages/(app)/quotes/_components/quote-preview-template.ts
@@ -5,6 +5,7 @@ import type { TemplateSettings } from "../../settings/_components/pdf.settings"
 import type { QuoteFormValues } from "./quote-form"
 import { formatAmount } from "@/lib/utils"
 import { getDraftWatermarkLabel } from "@/lib/watermark"
+import { isVatApplicable } from "@/lib/vat"
 
 /**
  * Frontend-only mirror of backend/src/modules/quotes/templates/base.template.ts, kept
@@ -38,6 +39,8 @@ export const quotePreviewTemplate = `
         .items-table th:nth-child(4), .items-table td:nth-child(4) { width: 16%; }
         .items-table th:nth-child(5), .items-table td:nth-child(5) { width: 9%; }
         .items-table th:nth-child(6), .items-table td:nth-child(6) { width: 18%; }
+        .items-table.no-vat th:nth-child(1), .items-table.no-vat td:nth-child(1) { width: 47%; }
+        .items-table.no-vat th:nth-child(5), .items-table.no-vat td:nth-child(5) { width: 18%; }
         .total-row { font-weight: bold; background-color: {{secondaryColor}}; color: {{tableTextColor}}; }
         .totals-table { width: 100%; border-collapse: collapse; margin: 0 0 20px; page-break-inside: avoid; break-inside: avoid; }
         .totals-table td:last-child { text-align: right; }
@@ -108,14 +111,16 @@ export const quotePreviewTemplate = `
             {{#if client.VAT}}<br><strong>{{labels.VATId}}:</strong> {{client.VAT}}{{/if}}</p>
         </div>
     </div>
-    <table class="items-table">
+    <table class="items-table{{#unless showVat}} no-vat{{/unless}}">
         <thead>
             <tr>
                 <th>{{labels.description}}</th>
                 <th>{{labels.type}}</th>
                 <th>{{labels.quantity}}</th>
                 <th>{{labels.unitPrice}}</th>
+                {{#if showVat}}
                 <th>{{labels.vatRate}}</th>
+                {{/if}}
                 <th>{{labels.total}}</th>
             </tr>
         </thead>
@@ -126,7 +131,9 @@ export const quotePreviewTemplate = `
                 <td>{{type}}</td>
                 <td>{{quantity}}</td>
                 <td>{{../currency}} {{unitPrice}}</td>
+                {{#if ../showVat}}
                 <td>{{vatRate}}%</td>
+                {{/if}}
                 <td>{{../currency}} {{totalPrice}}</td>
             </tr>
             {{/each}}
@@ -135,27 +142,29 @@ export const quotePreviewTemplate = `
     <table class="totals-table">
         <tbody>
             <tr>
-                <td colspan="5"><strong>{{labels.subtotal}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.subtotal}}</strong></td>
                 <td><strong>{{currency}} {{subtotalBeforeDiscount}}</strong></td>
             </tr>
             {{#if hasDiscount}}
             <tr>
-                <td colspan="5"><strong>{{labels.discount}} ({{discountRate}}%)</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.discount}} ({{discountRate}}%)</strong></td>
                 <td><strong>-{{currency}} {{discountAmount}}</strong></td>
             </tr>
             {{/if}}
+            {{#if showVat}}
             <tr>
-                <td colspan="5"><strong>{{labels.vat}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.vat}}</strong></td>
                 <td><strong>{{currency}} {{totalVAT}}</strong></td>
             </tr>
+            {{/if}}
             {{#if vatExemptText}}
             <tr>
                 <td></td>
-                <td colspan="5" style="font-size:12px; color:#666; text-align:right;"><em>{{vatExemptText}}</em></td>
+                <td colspan="{{totalsColspan}}" style="font-size:12px; color:#666; text-align:right;"><em>{{vatExemptText}}</em></td>
             </tr>
             {{/if}}
             <tr class="total-row">
-                <td colspan="5"><strong>{{labels.grandTotal}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{#if showVat}}{{labels.grandTotal}}{{else}}{{labels.total}}{{/if}}</strong></td>
                 <td><strong>{{currency}} {{totalTTC}}</strong></td>
             </tr>
         </tbody>
@@ -289,6 +298,7 @@ export function buildQuotePreviewData(
     const isVatExempt = !!(quote.company.exemptVat && (quote.company.country || "").toUpperCase() === "FRANCE")
     const totals = calculateDiscountedTotals(values.items, values.discountRate, isVatExempt)
     const hasDiscount = totals.discountRate > 0 && totals.discountAmountHT > 0
+    const showVat = isVatApplicable(totals.totalVAT, values.items)
 
     const clientName = quote.client.name || `${quote.client.contactFirstname || ""} ${quote.client.contactLastname || ""}`.trim()
 
@@ -315,6 +325,8 @@ export function buildQuotePreviewData(
         discountAmount: formatAmount(totals.discountAmountHT, quote.company.country),
         discountRate: Number(totals.discountRate.toFixed(2)),
         hasDiscount,
+        showVat,
+        totalsColspan: showVat ? 5 : 4,
         vatExemptText: isVatExempt ? "TVA non applicable, art. 293 B du CGI" : null,
 
         paymentMethod: paymentMethodType,

--- a/frontend/src/pages/(app)/quotes/_components/quote-view.tsx
+++ b/frontend/src/pages/(app)/quotes/_components/quote-view.tsx
@@ -4,6 +4,7 @@ import { PaymentMethodType, type PaymentMethod, type Quote } from "@/types"
 import { format } from "date-fns"
 import { languageToLocale } from "@/lib/i18n"
 import { formatAmount } from "@/lib/utils"
+import { isVatApplicable } from "@/lib/vat"
 import { useTranslation } from "react-i18next"
 
 interface QuoteViewDialogProps {
@@ -20,6 +21,7 @@ export function QuoteViewDialog({ quote, onOpenChange }: QuoteViewDialogProps) {
     const discountRateValue = Number(quote.discountRate ?? 0)
     const subtotalBeforeDiscount = quote.items?.reduce((sum, item) => sum + (item.quantity * item.unitPrice), 0) ?? 0
     const discountAmount = Math.max(0, subtotalBeforeDiscount - quote.totalHT)
+    const showVat = isVatApplicable(quote.totalVAT, quote.items)
 
     const getStatusLabel = (status: string) => {
         return t(`quotes.view.status.${status.toLowerCase()}`)
@@ -90,30 +92,42 @@ export function QuoteViewDialog({ quote, onOpenChange }: QuoteViewDialogProps) {
                         )}
                     </div>
 
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 bg-muted/50 p-4 rounded-lg">
-                        <div>
-                            <p className="text-sm text-muted-foreground">{t("quotes.view.fields.totalHT")}</p>
-                            <p className="font-medium">{t("common.valueWithCurrency", {
-                                currency: quote.currency,
-                                amount: formatAmount(quote.totalHT, quote.company?.country)
-                            })}</p>
-                        </div>
+                    <div className={`grid grid-cols-1 ${showVat ? "sm:grid-cols-3" : ""} gap-6 bg-muted/50 p-4 rounded-lg`}>
+                        {showVat ? (
+                            <>
+                                <div data-cy="quote-total-ht">
+                                    <p className="text-sm text-muted-foreground">{t("quotes.view.fields.totalHT")}</p>
+                                    <p className="font-medium">{t("common.valueWithCurrency", {
+                                        currency: quote.currency,
+                                        amount: formatAmount(quote.totalHT, quote.company?.country)
+                                    })}</p>
+                                </div>
 
-                        <div>
-                            <p className="text-sm text-muted-foreground">{t("quotes.view.fields.totalVAT")}</p>
-                            <p className="font-medium">{t("common.valueWithCurrency", {
-                                currency: quote.currency,
-                                amount: formatAmount(quote.totalVAT, quote.company?.country)
-                            })}</p>
-                        </div>
+                                <div data-cy="quote-total-vat">
+                                    <p className="text-sm text-muted-foreground">{t("quotes.view.fields.totalVAT")}</p>
+                                    <p className="font-medium">{t("common.valueWithCurrency", {
+                                        currency: quote.currency,
+                                        amount: formatAmount(quote.totalVAT, quote.company?.country)
+                                    })}</p>
+                                </div>
 
-                        <div>
-                            <p className="text-sm text-muted-foreground">{t("quotes.view.fields.totalTTC")}</p>
-                            <p className="font-medium">{t("common.valueWithCurrency", {
-                                currency: quote.currency,
-                                amount: formatAmount(quote.totalTTC, quote.company?.country)
-                            })}</p>
-                        </div>
+                                <div data-cy="quote-total-ttc">
+                                    <p className="text-sm text-muted-foreground">{t("quotes.view.fields.totalTTC")}</p>
+                                    <p className="font-medium">{t("common.valueWithCurrency", {
+                                        currency: quote.currency,
+                                        amount: formatAmount(quote.totalTTC, quote.company?.country)
+                                    })}</p>
+                                </div>
+                            </>
+                        ) : (
+                            <div data-cy="quote-total">
+                                <p className="text-sm text-muted-foreground">{t("quotes.view.fields.total")}</p>
+                                <p className="font-medium">{t("common.valueWithCurrency", {
+                                    currency: quote.currency,
+                                    amount: formatAmount(quote.totalTTC, quote.company?.country)
+                                })}</p>
+                            </div>
+                        )}
                     </div>
 
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 bg-muted/50 p-4 rounded-lg">

--- a/frontend/src/pages/(app)/settings/_components/pdf.settings.tsx
+++ b/frontend/src/pages/(app)/settings/_components/pdf.settings.tsx
@@ -108,7 +108,9 @@ const defaultInvoiceTemplate = `
                 <th>{{labels.type}}</th>
                 <th>{{labels.quantity}}</th>
                 <th>{{labels.unitPrice}}</th>
+                {{#if showVat}}
                 <th>{{labels.vatRate}}</th>
+                {{/if}}
                 <th>{{labels.total}}</th>
             </tr>
         </thead>
@@ -119,28 +121,32 @@ const defaultInvoiceTemplate = `
                 <td>{{type}}</td>
                 <td>{{quantity}}</td>
                 <td>{{../currency}} {{unitPrice}}</td>
+                {{#if ../showVat}}
                 <td>{{vatRate}}%</td>
+                {{/if}}
                 <td>{{../currency}} {{totalPrice}}</td>
             </tr>
             {{/each}}
         </tbody>
         <tfoot>
             <tr>
-                <td colspan="5"><strong>{{labels.subtotal}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.subtotal}}</strong></td>
                 <td><strong>{{currency}} {{subtotalBeforeDiscount}}</strong></td>
             </tr>
             {{#if hasDiscount}}
             <tr>
-                <td colspan="5"><strong>{{labels.discount}} ({{discountRate}}%)</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.discount}} ({{discountRate}}%)</strong></td>
                 <td><strong>-{{currency}} {{discountAmount}}</strong></td>
             </tr>
             {{/if}}
+            {{#if showVat}}
             <tr>
-                <td colspan="5"><strong>{{labels.vat}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.vat}}</strong></td>
                 <td><strong>{{currency}} {{totalVAT}}</strong></td>
             </tr>
+            {{/if}}
             <tr class="total-row">
-                <td colspan="5"><strong>{{labels.grandTotal}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{#if showVat}}{{labels.grandTotal}}{{else}}{{labels.total}}{{/if}}</strong></td>
                 <td><strong>{{currency}} {{totalTTC}}</strong></td>
             </tr>
         </tfoot>
@@ -239,7 +245,9 @@ const defaultQuoteTemplate = `
                 <th>{{labels.type}}</th>
                 <th>{{labels.quantity}}</th>
                 <th>{{labels.unitPrice}}</th>
+                {{#if showVat}}
                 <th>{{labels.vatRate}}</th>
+                {{/if}}
                 <th>{{labels.total}}</th>
             </tr>
         </thead>
@@ -250,28 +258,32 @@ const defaultQuoteTemplate = `
                 <td>{{type}}</td>
                 <td>{{quantity}}</td>
                 <td>{{../currency}} {{unitPrice}}</td>
+                {{#if ../showVat}}
                 <td>{{vatRate}}%</td>
+                {{/if}}
                 <td>{{../currency}} {{totalPrice}}</td>
             </tr>
             {{/each}}
         </tbody>
         <tfoot>
             <tr>
-                <td colspan="5"><strong>{{labels.subtotal}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.subtotal}}</strong></td>
                 <td><strong>{{currency}} {{subtotalBeforeDiscount}}</strong></td>
             </tr>
             {{#if hasDiscount}}
             <tr>
-                <td colspan="5"><strong>{{labels.discount}} ({{discountRate}}%)</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.discount}} ({{discountRate}}%)</strong></td>
                 <td><strong>-{{currency}} {{discountAmount}}</strong></td>
             </tr>
             {{/if}}
+            {{#if showVat}}
             <tr>
-                <td colspan="5"><strong>{{labels.vat}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{labels.vat}}</strong></td>
                 <td><strong>{{currency}} {{totalVAT}}</strong></td>
             </tr>
+            {{/if}}
             <tr class="total-row">
-                <td colspan="5"><strong>{{labels.grandTotal}}</strong></td>
+                <td colspan="{{totalsColspan}}"><strong>{{#if showVat}}{{labels.grandTotal}}{{else}}{{labels.total}}{{/if}}</strong></td>
                 <td><strong>{{currency}} {{totalTTC}}</strong></td>
             </tr>
         </tfoot>
@@ -641,6 +653,8 @@ export default function PDFTemplatesSettings() {
             totalTTC: "4320.00",
             totalBeforeDiscount: "4800.00",
             hasDiscount: true,
+            showVat: true,
+            totalsColspan: 5,
             currency: "EUR",
             fontFamily: settings.fontFamily,
             primaryColor: settings.primaryColor,


### PR DESCRIPTION
Fixes https://github.com/invoicerr-app/invoicerr/issues/242

When VAT is 0% or not applicable (USA / VAT-exempt documents), the app no longer shows both **Total (excl. VAT)** and **Total (incl. VAT)** — those amounts were identical and confusing. It now shows a single **Total**.

When a real VAT rate applies, the existing including/excluding VAT UI is unchanged.

## Behavior
- **No VAT** (`vatRate` 0 on all lines and `totalVAT` 0): lists, detail views, quote preview, and PDFs show **Total** only. PDF VAT rate column and VAT total row are omitted.
- **VAT applies** (any line `vatRate > 0` or `totalVAT > 0`): keep Total (excl. VAT), VAT amount, and Total (incl. VAT). PDFs keep the VAT column and VAT row.

France 293 B CGI exempt notices are unchanged.

## Tests
- Unit tests for `isVatApplicable` and invoice/quote PDF HTML for both cases
- Cypress: 20% invoice still shows HT/VAT/TTC; 0% invoice shows a single Total

Does not merge. Does not send invoices.